### PR TITLE
Add nodeagent debug endpoints [Issue 15416]

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -122,6 +122,7 @@ const (
 
 	MonitoringPort  = "MONITORING_PORT"
 	EnableProfiling = "ENABLE_PROFILING"
+	DebugPort       = "DEBUG_PORT"
 )
 
 var (
@@ -249,6 +250,8 @@ var (
 	initialBackoffEnv                  = env.RegisterIntVar(InitialBackoff, 10, "").Get()
 	monitoringPortEnv                  = env.RegisterIntVar(MonitoringPort, 15014,
 		"The port number for monitoring Citadel agent").Get()
+	debugPortEnv = env.RegisterIntVar(DebugPort, 8080,
+		"Debug endpoints dump SDS configuration and connection data from this port").Get()
 	enableProfilingEnv = env.RegisterBoolVar(EnableProfiling, true,
 		"Enabling profiling when monitoring Citadel agent").Get()
 )
@@ -323,6 +326,8 @@ func applyEnvVars(cmd *cobra.Command) {
 	if !cmd.Flag(InitialBackoffFlag).Changed {
 		workloadSdsCacheOptions.InitialBackoff = int64(initialBackoffEnv)
 	}
+
+	serverOptions.DebugPort = debugPortEnv
 }
 
 func validateOptions() error {


### PR DESCRIPTION
Add debug endpoints to the k8s_node_agent- [addresses this issue](https://github.com/istio/istio/issues/15416).

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
